### PR TITLE
Set ALLOWED_HOSTS to '*' (all) in settings.py

### DIFF
--- a/inventory_project/settings.py
+++ b/inventory_project/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['0.0.0.0', '10.247.58.113']
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition


### PR DESCRIPTION
Make this usuable by allowing any browser to use django.